### PR TITLE
Add --path-glob flag for doublestar glob filtering of configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
 #
 # Binaries for programs and plugins
+/pantalon
 *.exe
 *.exe~
 *.dll

--- a/cmd/pantalon/main.go
+++ b/cmd/pantalon/main.go
@@ -11,9 +11,20 @@ import (
 	"github.com/kallangerard/pantalon/file"
 )
 
+// pathGlobs implements flag.Value for a repeatable --path-glob flag.
+type pathGlobs []string
+
+func (p *pathGlobs) String() string { return fmt.Sprintf("%v", *p) }
+func (p *pathGlobs) Set(v string) error {
+	*p = append(*p, v)
+	return nil
+}
+
 func main() {
 	outputFormat := flag.String("output-format", "json", "Output format (json)")
 	changedDirsJson := flag.String("changed-dirs", "", `[".", "foo", "foo/bar"]`)
+	var globs pathGlobs
+	flag.Var(&globs, "path-glob", "Doublestar glob pattern to filter configurations by directory path (repeatable, OR logic)")
 	flag.Parse()
 
 	configurations, err := file.Search()
@@ -39,6 +50,13 @@ func main() {
 		}
 	} else {
 		items = unfilteredItems
+	}
+
+	if len(globs) > 0 {
+		items, err = file.GlobFilter(items, globs)
+		if err != nil {
+			log.Fatalf("Error filtering by path glob: %v", err)
+		}
 	}
 
 	switch *outputFormat {

--- a/file/glob.go
+++ b/file/glob.go
@@ -1,0 +1,28 @@
+package file
+
+import (
+	"github.com/bmatcuk/doublestar/v4"
+	"github.com/kallangerard/pantalon/api"
+)
+
+// GlobFilter returns items whose Dir matches any of the provided doublestar glob patterns.
+func GlobFilter(items []api.ConfigurationItem, patterns []string) ([]api.ConfigurationItem, error) {
+	if len(patterns) == 0 {
+		return items, nil
+	}
+
+	filtered := make([]api.ConfigurationItem, 0)
+	for _, item := range items {
+		for _, pattern := range patterns {
+			matched, err := doublestar.Match(pattern, item.Dir)
+			if err != nil {
+				return nil, err
+			}
+			if matched {
+				filtered = append(filtered, item)
+				break
+			}
+		}
+	}
+	return filtered, nil
+}

--- a/file/glob_property_test.go
+++ b/file/glob_property_test.go
@@ -1,0 +1,148 @@
+package file
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"pgregory.net/rapid"
+
+	"github.com/kallangerard/pantalon/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// genSegment produces a path segment: starts with a-z, then any mix of
+// lowercase letters, digits, hyphens, underscores, and dots (0-19 extra chars).
+func genSegment() *rapid.Generator[string] {
+	return rapid.StringMatching(`[a-z][a-z0-9\-_.]{0,19}`)
+}
+
+// genDirPath produces a slash-joined directory path with 1-8 segments.
+func genDirPath() *rapid.Generator[string] {
+	return rapid.Custom(func(t *rapid.T) string {
+		depth := rapid.IntRange(1, 8).Draw(t, "depth")
+		segments := make([]string, depth)
+		for i := range segments {
+			segments[i] = genSegment().Draw(t, fmt.Sprintf("seg%d", i))
+		}
+		return strings.Join(segments, "/")
+	})
+}
+
+// genItem produces a ConfigurationItem with a generated directory path.
+func genItem() *rapid.Generator[api.ConfigurationItem] {
+	return rapid.Custom(func(t *rapid.T) api.ConfigurationItem {
+		dir := genDirPath().Draw(t, "dir")
+		return api.ConfigurationItem{
+			Name: genSegment().Draw(t, "name"),
+			Dir:  dir,
+			Path: dir + "/pantalon.yaml",
+		}
+	})
+}
+
+// genItems produces a slice of 0-10 ConfigurationItems.
+func genItems() *rapid.Generator[[]api.ConfigurationItem] {
+	return rapid.SliceOfN(genItem(), 0, 10)
+}
+
+// Property: no patterns returns all items unchanged.
+func TestGlobFilter_Property_NoPatternsReturnsAll(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		items := genItems().Draw(t, "items")
+		result, err := GlobFilter(items, []string{})
+		require.NoError(t, err)
+		assert.Equal(t, items, result)
+	})
+}
+
+// Property: "**" matches every directory path regardless of depth or characters.
+func TestGlobFilter_Property_DoubleStarMatchesAll(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		items := genItems().Draw(t, "items")
+		result, err := GlobFilter(items, []string{"**"})
+		require.NoError(t, err)
+		assert.Equal(t, items, result)
+	})
+}
+
+// Property: an exact-dir pattern always matches that item.
+func TestGlobFilter_Property_ExactPatternMatchesItem(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		item := genItem().Draw(t, "item")
+		result, err := GlobFilter([]api.ConfigurationItem{item}, []string{item.Dir})
+		require.NoError(t, err)
+		assert.Contains(t, result, item)
+	})
+}
+
+// Property: every item in the result was present in the input.
+func TestGlobFilter_Property_ResultIsSubsetOfInput(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		items := genItems().Draw(t, "items")
+		pattern := genDirPath().Draw(t, "pattern")
+		result, err := GlobFilter(items, []string{pattern})
+		require.NoError(t, err)
+		for _, r := range result {
+			assert.Contains(t, items, r)
+		}
+	})
+}
+
+// Property: an item matching multiple patterns appears exactly once (no duplicates).
+func TestGlobFilter_Property_NoDuplicatesOnMultiplePatternMatch(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		item := genItem().Draw(t, "item")
+		// item.Dir and "**" both match the item.
+		result, err := GlobFilter([]api.ConfigurationItem{item}, []string{item.Dir, "**"})
+		require.NoError(t, err)
+		assert.Len(t, result, 1)
+	})
+}
+
+// Property: adding more patterns never reduces the result size (OR semantics).
+func TestGlobFilter_Property_ORMonotonicity(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		items := genItems().Draw(t, "items")
+		p1 := genDirPath().Draw(t, "p1")
+		p2 := genDirPath().Draw(t, "p2")
+
+		r1, err := GlobFilter(items, []string{p1})
+		require.NoError(t, err)
+		r12, err := GlobFilter(items, []string{p1, p2})
+		require.NoError(t, err)
+
+		assert.GreaterOrEqual(t, len(r12), len(r1))
+	})
+}
+
+// Property: "*" does not match a multi-segment path.
+func TestGlobFilter_Property_SingleStarDoesNotCrossSegments(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		// Generate a dir with at least 2 segments.
+		seg1 := genSegment().Draw(t, "seg1")
+		seg2 := genSegment().Draw(t, "seg2")
+		dir := seg1 + "/" + seg2
+		item := api.ConfigurationItem{Name: "x", Dir: dir, Path: dir + "/pantalon.yaml"}
+
+		result, err := GlobFilter([]api.ConfigurationItem{item}, []string{"*"})
+		require.NoError(t, err)
+		assert.NotContains(t, result, item)
+	})
+}
+
+// Property: "prefix/**" matches any path whose first segment equals prefix.
+func TestGlobFilter_Property_PrefixDoubleStarMatchesChildren(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		prefix := genSegment().Draw(t, "prefix")
+		// Generate the remainder (at least one more segment).
+		rest := genDirPath().Draw(t, "rest")
+		dir := prefix + "/" + rest
+		item := api.ConfigurationItem{Name: "x", Dir: dir, Path: dir + "/pantalon.yaml"}
+
+		result, err := GlobFilter([]api.ConfigurationItem{item}, []string{prefix + "/**"})
+		require.NoError(t, err)
+		assert.Contains(t, result, item)
+	})
+}

--- a/file/glob_test.go
+++ b/file/glob_test.go
@@ -1,0 +1,57 @@
+package file
+
+import (
+	"testing"
+
+	"github.com/kallangerard/pantalon/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var globItems = []api.ConfigurationItem{
+	{Name: "compute-dev", Path: "terraform/compute/environments/dev/pantalon.yaml", Dir: "terraform/compute/environments/dev"},
+	{Name: "compute-prod", Path: "terraform/compute/environments/prod/pantalon.yaml", Dir: "terraform/compute/environments/prod"},
+	{Name: "network-dev", Path: "terraform/network/environments/dev/pantalon.yaml", Dir: "terraform/network/environments/dev"},
+	{Name: "network-prod", Path: "terraform/network/environments/prod/pantalon.yaml", Dir: "terraform/network/environments/prod"},
+}
+
+func TestGlobFilter_DoublestarRecursive(t *testing.T) {
+	result, err := GlobFilter(globItems, []string{"terraform/compute/**"})
+	require.NoError(t, err)
+	assert.Equal(t, []api.ConfigurationItem{globItems[0], globItems[1]}, result)
+}
+
+func TestGlobFilter_SingleSegmentWildcard(t *testing.T) {
+	result, err := GlobFilter(globItems, []string{"terraform/*/environments/dev"})
+	require.NoError(t, err)
+	assert.Equal(t, []api.ConfigurationItem{globItems[0], globItems[2]}, result)
+}
+
+func TestGlobFilter_MultiplePatterns_OR(t *testing.T) {
+	result, err := GlobFilter(globItems, []string{"terraform/compute/**", "terraform/network/environments/prod"})
+	require.NoError(t, err)
+	assert.Equal(t, []api.ConfigurationItem{globItems[0], globItems[1], globItems[3]}, result)
+}
+
+func TestGlobFilter_NoPatterns_ReturnsAll(t *testing.T) {
+	result, err := GlobFilter(globItems, []string{})
+	require.NoError(t, err)
+	assert.Equal(t, globItems, result)
+}
+
+func TestGlobFilter_NoMatch(t *testing.T) {
+	result, err := GlobFilter(globItems, []string{"terraform/storage/**"})
+	require.NoError(t, err)
+	assert.Equal(t, []api.ConfigurationItem{}, result)
+}
+
+func TestGlobFilter_ExactMatch(t *testing.T) {
+	result, err := GlobFilter(globItems, []string{"terraform/compute/environments/dev"})
+	require.NoError(t, err)
+	assert.Equal(t, []api.ConfigurationItem{globItems[0]}, result)
+}
+
+func TestGlobFilter_InvalidPattern(t *testing.T) {
+	_, err := GlobFilter(globItems, []string{"["})
+	assert.Error(t, err)
+}

--- a/file/glob_test.go
+++ b/file/glob_test.go
@@ -9,10 +9,26 @@ import (
 )
 
 var globItems = []api.ConfigurationItem{
-	{Name: "compute-dev", Path: "terraform/compute/environments/dev/pantalon.yaml", Dir: "terraform/compute/environments/dev"},
-	{Name: "compute-prod", Path: "terraform/compute/environments/prod/pantalon.yaml", Dir: "terraform/compute/environments/prod"},
-	{Name: "network-dev", Path: "terraform/network/environments/dev/pantalon.yaml", Dir: "terraform/network/environments/dev"},
-	{Name: "network-prod", Path: "terraform/network/environments/prod/pantalon.yaml", Dir: "terraform/network/environments/prod"},
+	{
+		Name: "compute-dev",
+		Path: "terraform/compute/environments/dev/pantalon.yaml",
+		Dir:  "terraform/compute/environments/dev",
+	},
+	{
+		Name: "compute-prod",
+		Path: "terraform/compute/environments/prod/pantalon.yaml",
+		Dir:  "terraform/compute/environments/prod",
+	},
+	{
+		Name: "network-dev",
+		Path: "terraform/network/environments/dev/pantalon.yaml",
+		Dir:  "terraform/network/environments/dev",
+	},
+	{
+		Name: "network-prod",
+		Path: "terraform/network/environments/prod/pantalon.yaml",
+		Dir:  "terraform/network/environments/prod",
+	},
 }
 
 func TestGlobFilter_DoublestarRecursive(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kallangerard/pantalon
 go 1.23.4
 
 require (
+	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/goccy/go-yaml v1.19.2
 	github.com/stretchr/testify v1.11.1
 )

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/goccy/go-yaml v1.19.2
 	github.com/stretchr/testify v1.11.1
+	pgregory.net/rapid v1.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/goccy/go-yaml v1.15.17 h1:dK4FbbTTEOZTLH/NW3/xBqg0JdC14YKVmYwS9GT3H60=

--- a/go.sum
+++ b/go.sum
@@ -32,3 +32,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+pgregory.net/rapid v1.3.0 h1:vBvO0VSqti75J1jjYqpgPNBLKMd1+gxa9fYo7vk/Exc=
+pgregory.net/rapid v1.3.0/go.mod h1:dPlE4OBBxgXPqkP79flB6sJL1dx5azpI7HQ9MY9Z7uk=


### PR DESCRIPTION
Introduces a repeatable --path-glob flag that filters discovered
TerraformConfiguration items to those whose directory matches any of
the supplied doublestar glob patterns (OR logic). Applied after
--changed-dirs filtering when both flags are present.

https://claude.ai/code/session_01CgusqQBKwRmNQSasf9icq4