### PR TITLE
docs: document path glob filtering and add prod example workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,63 @@ The changed-dirs argument has been designed to be supplied by [tj-actions/change
         dir_names: "true"
 ```
 
+### Path Glob Filtering
+
+Pantalon can filter configurations by directory path using [doublestar](https://github.com/bmatcuk/doublestar) glob patterns. Pass `--path-glob` one or more times; a configuration is included if its directory matches **any** of the supplied patterns (OR logic).
+
+```shell
+# All configurations under terraform/compute
+pantalon --output-format=yaml --path-glob='terraform/compute/**'
+```
+
+```yaml
+- name: compute-dev
+  path: terraform/compute/environments/dev/pantalon.yaml
+  dir: terraform/compute/environments/dev
+  context:
+    gcp-service-account: infrastructure@pantalon-dev.iam.gserviceaccount.com
+- name: compute-prod
+  path: terraform/compute/environments/prod/pantalon.yaml
+  dir: terraform/compute/environments/prod
+  context:
+    gcp-service-account: infrastructure@pantalon-prod.iam.gserviceaccount.com
+- name: compute-qa
+  path: terraform/compute/environments/qa/pantalon.yaml
+  dir: terraform/compute/environments/qa
+  context:
+    gcp-service-account: infrastructure@pantalon-qa.iam.gserviceaccount.com
+```
+
+Use `*` to match a single path segment and `**` to match any number of segments:
+
+| Pattern | Matches |
+|---|---|
+| `terraform/compute/**` | Every configuration nested under `terraform/compute/` |
+| `**/environments/prod` | Every `prod` environment regardless of component |
+| `terraform/*/environments/dev` | Every `dev` environment, one component level deep |
+| `terraform/compute/environments/dev` | Exact directory match |
+
+Multiple `--path-glob` flags are combined with OR logic — a configuration is included if it matches at least one pattern:
+
+```shell
+# Production environments for compute and data only
+pantalon --output-format=yaml \
+  --path-glob='terraform/compute/environments/prod' \
+  --path-glob='terraform/data/environments/prod'
+```
+
+`--path-glob` can be combined with `--changed-dirs`. Changed-dirs filtering is applied first, and glob filtering is applied to the result:
+
+```shell
+pantalon --output-format=yaml \
+  --changed-dirs='["terraform/compute/environments/dev","terraform/data/environments/dev"]' \
+  --path-glob='terraform/compute/**'
+```
+
+This returns only changed configurations that also match the glob — in this case, just `compute-dev`.
+
+See the [path glob example](examples/.github/workflows/terraform-plan-prod.yaml) for a GitHub Actions workflow that uses `--path-glob` to target production environments.
+
 ### Matrix
 
 The primary intent is to  use Pantalon to generate a matrix of configurations to be executed by a GitHub Actions.

--- a/examples/.github/workflows/terraform-plan-prod.yaml
+++ b/examples/.github/workflows/terraform-plan-prod.yaml
@@ -1,0 +1,77 @@
+name: Terraform Plan (Production)
+
+# Demonstrates using --path-glob to target only production environments.
+# This workflow runs on every push to main and plans all prod configurations,
+# regardless of which files changed.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.tf"
+      - "**/*.tfvars"
+      - "**/pantalon.yaml"
+
+jobs:
+  define-matrix:
+    name: Define Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      configs: ${{ steps.pantalon.outputs.configs }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Pantalon
+        run: |
+          echo "TODO:"
+
+      - name: Get Pantalon Configs
+        id: pantalon
+        run: |
+          # Use --path-glob to restrict output to production environments only.
+          # Pass --path-glob multiple times to add more patterns (OR logic).
+          CONFIGS=$(pantalon --path-glob='**/environments/prod')
+
+          echo "Configs: "
+          echo "$CONFIGS" | jq '.'
+          echo "configs=$CONFIGS" >> "$GITHUB_OUTPUT"
+
+  plan:
+    name: ${{ matrix.configs.name }}
+    needs:
+      - define-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        configs: ${{ fromJSON(needs.define-matrix.outputs.configs) }}
+    defaults:
+      run:
+        working-directory: ${{ matrix.configs.dir }}
+    env:
+      TF_IN_AUTOMATION: "true"
+      TF_INPUT: "false"
+
+    permissions:
+      contents: "read"
+      id-token: "write"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: google-github-actions/auth@v2
+        with:
+          service_account: ${{ matrix.configs.context.gcp-service-account }}
+          workload_identity_provider: projects/12345678912345/locations/global/workloadIdentityPools/my-identity-pool/providers/my-provider
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.10.5
+
+      - name: Terraform Plan
+        run: |
+          terraform init
+          terraform plan


### PR DESCRIPTION
Adds a Path Glob Filtering section to the README explaining the
--path-glob flag, doublestar pattern syntax, OR logic for multiple
patterns, and combination with --changed-dirs.

Adds examples/.github/workflows/terraform-plan-prod.yaml showing how
to use --path-glob to target only production environments on push to
main.

https://claude.ai/code/session_01JFPRXnE7hN4ser16dPJSTn