### PR TITLE
fix(renovate): use matchDepNames to automerge go patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,10 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "packageRules": [
     {
       "matchManagers": ["gomod"],
+      "matchDepNames": ["go"],
       "matchUpdateTypes": ["patch"],
       "automerge": true
     }

--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
-      "matchManagers": ["gomod"],
-      "matchDepNames": ["go"],
+      "matchPackageNames": ["go"],
       "matchUpdateTypes": ["patch"],
       "automerge": true
     }

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
-      "matchPackageNames": ["go"],
+      "matchDepNames": ["go"],
       "matchUpdateTypes": ["patch"],
       "automerge": true
     }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Fixes automerge not triggering for the `go` dependency (PR #63)
- `matchPackageNames` does not match `uses-with` type GitHub Actions deps; `matchDepNames` is the correct field for matching the dep name `go` regardless of manager

## Test plan

- [ ] Merge and re-run Renovate — PR #63 should be automerged
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZ5ZpGUeToMNE5xui33ShQ)_