### PR TITLE
ci(claude): golangci-lint install to session-start hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-# Only run in remote Claude Code environments
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
@@ -10,3 +9,9 @@ cd "$CLAUDE_PROJECT_DIR"
 
 # Download Go module dependencies
 go mod download
+
+# Install golangci-lint if not already present
+if ! command -v golangci-lint &>/dev/null; then
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+    | sh -s -- -b "$(go env GOPATH)/bin"
+fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+echo '{"async": true, "asyncTimeout": 300000}'
+
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi


### PR DESCRIPTION
Ensures golangci-lint is available in web sessions so changes can be
linted without relying on CI.

https://claude.ai/code/session_01G6ZT2MQKb959mTuvK2jp3F