### PR TITLE
fix(release): add explicit packages block to resolve v5 component mismatch

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "go",
-  "initial-version": "0.1.0"
+  "initial-version": "0.1.0",
+  "packages": {
+    ".": {}
+  }
 }


### PR DESCRIPTION
Release-please v5 was warning "Found release tag with component '',
but not configured in manifest", leaving the baseline SHA set empty
and collecting 0 releaseable commits on every run.

Adding an explicit packages entry for "." makes the root component
unambiguous so v5 can match the v0.1.0 tag to the manifest and
correctly collect commits since that release.

https://claude.ai/code/session_01KLYJQtuKVyT58abUpjMPac