### PR TITLE
fix: allow not passing changed-dirs

### DIFF
--- a/cmd/pantalon/main.go
+++ b/cmd/pantalon/main.go
@@ -69,26 +69,9 @@ func main() {
 		log.Fatalf("Error marshaling items: %v", err)
 	}
 
-	var items = []api.ConfigurationItem{}
-
-	if changedDirsJson != nil {
-		changedDirs, err := api.UnmarshalChangedFileJson([]byte(*changedDirsJson))
-		if err != nil {
-			log.Fatalf("Error unmarshaling changed dirs: %v", err)
-		}
-		items, err = file.ChangedFiles(unfilteredItems, changedDirs)
-		if err != nil {
-			log.Fatalf("Error filtering changed files: %v", err)
-		}
-	} else {
-		items = unfilteredItems
-	}
-
-	if len(globs) > 0 {
-		items, err = file.GlobFilter(items, globs)
-		if err != nil {
-			log.Fatalf("Error filtering by path glob: %v", err)
-		}
+	items, err := filterItems(unfilteredItems, *changedDirsJson, globs)
+	if err != nil {
+		log.Fatalf("Error filtering items: %v", err)
 	}
 
 	switch *outputFormat {
@@ -99,6 +82,33 @@ func main() {
 	default:
 		log.Fatalf("Unsupported output format: %s", *outputFormat)
 	}
+}
+
+func filterItems(unfilteredItems []api.ConfigurationItem, changedDirsJson string, globs []string) ([]api.ConfigurationItem, error) {
+	var items []api.ConfigurationItem
+
+	if changedDirsJson != "" {
+		changedDirs, err := api.UnmarshalChangedFileJson([]byte(changedDirsJson))
+		if err != nil {
+			return nil, fmt.Errorf("error unmarshaling changed dirs: %w", err)
+		}
+		items, err = file.ChangedFiles(unfilteredItems, changedDirs)
+		if err != nil {
+			return nil, fmt.Errorf("error filtering changed files: %w", err)
+		}
+	} else {
+		items = unfilteredItems
+	}
+
+	if len(globs) > 0 {
+		var err error
+		items, err = file.GlobFilter(items, globs)
+		if err != nil {
+			return nil, fmt.Errorf("error filtering by path glob: %w", err)
+		}
+	}
+
+	return items, nil
 }
 
 func outputJson(configurations []api.ConfigurationItem) {

--- a/cmd/pantalon/main_test.go
+++ b/cmd/pantalon/main_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/kallangerard/pantalon/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var filterTestItems = []api.ConfigurationItem{
+	{
+		Name: "compute-dev",
+		Path: "terraform/compute/environments/dev/pantalon.yaml",
+		Dir:  "terraform/compute/environments/dev",
+	},
+	{
+		Name: "compute-prod",
+		Path: "terraform/compute/environments/prod/pantalon.yaml",
+		Dir:  "terraform/compute/environments/prod",
+	},
+	{
+		Name: "network-dev",
+		Path: "terraform/network/environments/dev/pantalon.yaml",
+		Dir:  "terraform/network/environments/dev",
+	},
+	{
+		Name: "network-prod",
+		Path: "terraform/network/environments/prod/pantalon.yaml",
+		Dir:  "terraform/network/environments/prod",
+	},
+}
+
+func TestFilterItems_PathGlobDefined_NoChangedDirs(t *testing.T) {
+	result, err := filterItems(filterTestItems, "", []string{"terraform/compute/**"})
+	require.NoError(t, err)
+	assert.Equal(t, []api.ConfigurationItem{filterTestItems[0], filterTestItems[1]}, result)
+}
+
+func TestFilterItems_NoChangedDirs_ReturnsAllItems(t *testing.T) {
+	result, err := filterItems(filterTestItems, "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, filterTestItems, result)
+}


### PR DESCRIPTION
Extract filtering pipeline from main() into a testable filterItems()
function, fixing a latent bug where changedDirsJson != nil was always
true (flag.String never returns nil) causing a fatal JSON parse error
when --changed-dirs was not provided. Add tests for:
- path glob defined with no changed dirs (glob filters correctly)
- no changed dirs defined (all items returned unchanged)

https://claude.ai/code/session_01UkEUNt8SHcGhdmkgU2bSGj