### PR TITLE
fix: dedupe ChangedFiles output to avoid duplicate matrix jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ The changed-dirs argument has been designed to be supplied by [tj-actions/change
         dir_names: "true"
 ```
 
+Each matching configuration is only emitted once, even if multiple entries in `--changed-dirs` fall within the same configuration's directory (for example, separate files changed in two different submodules of the same root module). This avoids generating duplicate matrix jobs for the same `pantalon.yaml`.
+
 ### Path Glob Filtering
 
 Pantalon can filter configurations by directory path using [doublestar](https://github.com/bmatcuk/doublestar) glob patterns. Pass `--path-glob` one or more times; a configuration is included if its directory matches **any** of the supplied patterns (OR logic).

--- a/file/changed.go
+++ b/file/changed.go
@@ -14,6 +14,7 @@ func ChangedFiles(allItems []api.ConfigurationItem, changedDirs []string) ([]api
 		for _, dir := range changedDirs {
 			if dir == "." || strings.HasPrefix(dir, cfg.Dir) || strings.HasPrefix(cfg.Dir, dir) {
 				filteredCfgs = append(filteredCfgs, cfg)
+				break
 			}
 		}
 	}

--- a/file/changed_test.go
+++ b/file/changed_test.go
@@ -229,6 +229,49 @@ func TestChangedDirs_Mixed(t *testing.T) {
 	assert.Equal(t, expectedFilteredCfgs, filteredCfgs)
 }
 
+// If multiple changed directories fall within the same Pantalon configuration,
+// that configuration must only be returned once. Otherwise the same
+// pantalon.yaml is emitted multiple times, producing duplicate matrix jobs.
+func TestChangedDirs_MultipleChangedDirsWithinSameConfig(t *testing.T) {
+
+	cfgs := []api.TerraformConfiguration{
+		{
+			Metadata: api.Metadata{Name: "item1"},
+			Path:     "a/b/1/pantalon.yaml",
+		},
+	}
+
+	expectedFilteredCfgs := []api.ConfigurationItem{
+		{
+			Name: "item1",
+			Path: "a/b/1/pantalon.yaml",
+			Dir:  "a/b/1",
+		},
+	}
+
+	// Two files changed in different subdirectories of the same Pantalon
+	// configuration (e.g. two separate modules under a/b/1) result in two
+	// entries in changed-dirs that both match a/b/1.
+	changedFilesJson := []byte(`["a/b/1/modules/foo", "a/b/1/modules/bar"]`)
+
+	items, err := api.MarshalItems(cfgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changedDirs, err := api.UnmarshalChangedFileJson(changedFilesJson)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	filteredCfgs, err := ChangedFiles(items, changedDirs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, expectedFilteredCfgs, filteredCfgs)
+}
+
 // If a directory changed is nested inside a Pantalon directory, the pantalon directory should be returned
 func TestChangedDirs_ChangedDirInsidePantalonCfg(t *testing.T) {
 


### PR DESCRIPTION
ChangedFiles appended a configuration once per matching changed-dir
entry, so multiple changed files/subdirectories within the same
Pantalon root module produced duplicate items, generating duplicate
matrix jobs for the same pantalon.yaml.

https://claude.ai/code/session_01FD7UN4dU6Hp15i4jsWSk9F